### PR TITLE
feat: use bibliotheque for component images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # schéma de plomberie
 Logiciel sans installation de réalisation simple d'installations
+
+## Bibliothèque de composants
+
+Ajoutez vos images de composants (SVG, JPG, WebP) dans le dossier
+`bibliotheque/` à la racine du projet. Les sous-dossiers deviennent des
+catégories dans l'interface.

--- a/bibliotheque/README.md
+++ b/bibliotheque/README.md
@@ -1,0 +1,2 @@
+Ajoutez ici vos composants (images SVG, JPG, WebP).
+Les sous-dossiers servent de catégories dans l'application.

--- a/plumb_sketch_editeur_de_schemas_plomberie_html_standalone.html
+++ b/plumb_sketch_editeur_de_schemas_plomberie_html_standalone.html
@@ -112,10 +112,10 @@
         </label>
       </div>
       <div class="row"><button id="lockBgBtn">🔒 Verrouiller fond</button></div>
-      <div class="small">
-        Placez vos images PNG/JPG/WebP dans <span class="kbd">/composants/</span>. Les <b>sous-dossiers</b> deviennent des catégories.
-        Option : <span class="kbd">/composants/_index.json</span> pour accélérer le chargement.
-      </div>
+        <div class="small">
+          Placez vos images SVG/JPG/WebP dans <span class="kbd">bibliotheque/</span>. Les <b>sous-dossiers</b> deviennent des catégories.
+          Option : <span class="kbd">bibliotheque/_index.json</span> pour accélérer le chargement.
+        </div>
     </div>
   </main>
 </div>
@@ -276,17 +276,17 @@
   // Zoom (Ctrl+wheel)
   let scale=1; document.getElementById('workwrap').addEventListener('wheel',e=>{ if(!e.ctrlKey) return; e.preventDefault(); scale=Math.min(2,Math.max(0.4, scale+(e.deltaY<0?0.1:-0.1))); svg.style.transformOrigin='0 0'; svg.style.transform=`scale(${scale})`; document.getElementById('zoom').textContent=Math.round(scale*100)+'%'; },{passive:false});
 
-  // Démo + chargement auto depuis /composants
+  // Démo + chargement auto depuis /bibliotheque
   placeDemo(); loadExternalComponents();
 
   function placeDemo(){ ['pipe-straight','elbow-90','tee','valve','tap'].forEach((id,i)=>{ const m=library.find(x=>x.id===id); const g=createComponentInstance(m, 420+i*200, 320); compLayer.appendChild(g); }); }
 
-  // === Auto-bibliothèque depuis /composants ===
+  // === Auto-bibliothèque depuis /bibliotheque ===
   async function loadExternalComponents(){
     let entries=[];
     // 1) index JSON optionnel
     try{
-      const res=await fetch('/composants/_index.json',{cache:'no-store'});
+      const res=await fetch('bibliotheque/_index.json',{cache:'no-store'});
       if(res.ok){
         const data=await res.json();
         if(Array.isArray(data)) entries=data;
@@ -296,7 +296,7 @@
     // 2) sinon, tenter un listing HTML (autoindex)
     if(entries.length===0){
       try{
-        const res=await fetch('/composants/'); if(res.ok){ const html=await res.text(); const files=parseLinksFromListing(html,'/composants/'); entries.push(...files.map(p=>({name:basename(p), cat:inferCatFromPath(p)||'Autres', path:p}))); }
+        const res=await fetch('bibliotheque/'); if(res.ok){ const html=await res.text(); const files=parseLinksFromListing(html,'bibliotheque/'); entries.push(...files.map(p=>({name:basename(p), cat:inferCatFromPath(p)||'Autres', path:p}))); }
       }catch(e){}
     }
     // 3) Hydrate UI
@@ -309,7 +309,7 @@
   }
 
   // Schéma de nommage fichiers :
-  // /composants/<Categorie>/<Nom_du_composant>@64.png
+  // bibliotheque/<Categorie>/<Nom_du_composant>@64.svg
   // - Catégorie = nom du sous-dossier (ex. Raccords, Vannes, Sanitaires…)
   // - Nom = nom de fichier sans extension, "_" -> espace (ex. "Vanne_papillon")
   // - Suffixe optionnel "@64" pour une taille préférée d’aperçu (ignoré si absent)
@@ -322,7 +322,7 @@
   function basename(p){ const a=p.split('/'); return decodeURIComponent(a[a.length-1]||p); }
   function prettyName(file){ return file.replace(/\\.[a-z0-9]+$/i,'').replace(/@\\d+$/,'').replace(/[_-]+/g,' ').trim(); }
   function parsePreferredSize(file){ const m=/@(\\d+)(?=\\.[a-z0-9]+$|$)/i.exec(file); return m? Math.max(40, Math.min(160, +m[1])) : null; }
-  function parseLinksFromListing(html,base){ const div=document.createElement('div'); div.innerHTML=html; const exts=['.png','.jpg','.jpeg','.webp']; const anchors=[...div.querySelectorAll('a')]; const urls=anchors.map(a=>a.getAttribute('href')||'').filter(h=>exts.some(ext=>h.toLowerCase().endsWith(ext))); return urls.map(u=>u.startsWith('http')?u:(base+u).replace(/\\\\/g,'/')); }
+  function parseLinksFromListing(html,base){ const div=document.createElement('div'); div.innerHTML=html; const exts=['.jpg','.jpeg','.webp','.svg']; const anchors=[...div.querySelectorAll('a')]; const urls=anchors.map(a=>a.getAttribute('href')||'').filter(h=>exts.some(ext=>h.toLowerCase().endsWith(ext))); return urls.map(u=>u.startsWith('http')?u:(base+u).replace(/\\\\/g,'/')); }
 
   // Helpers SVG
   function svgEl(n){ return document.createElementNS('http://www.w3.org/2000/svg',n); }


### PR DESCRIPTION
## Summary
- load components from new `bibliotheque/` folder
- document how to add custom components and include sample
- support SVG files in auto-discovered library
- use relative `bibliotheque` paths so static deployments work
- drop PNG support for component library

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5dbf1b48832a8f00c259ca844c79